### PR TITLE
deps: updates wazero to 1.0.0-pre.4

### DIFF
--- a/cmd/host/go.mod
+++ b/cmd/host/go.mod
@@ -4,5 +4,5 @@ go 1.19
 
 require (
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/tetratelabs/wazero v1.0.0-pre.3
+	github.com/tetratelabs/wazero v1.0.0-pre.4
 )

--- a/cmd/host/go.sum
+++ b/cmd/host/go.sum
@@ -1,4 +1,4 @@
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
-github.com/tetratelabs/wazero v1.0.0-pre.3 h1:Z5fbogMUGcERzaQb9mQU8+yJSy0bVvv2ce3dfR4wcZg=
-github.com/tetratelabs/wazero v1.0.0-pre.3/go.mod h1:M8UDNECGm/HVjOfq0EOe4QfCY9Les1eq54IChMLETbc=
+github.com/tetratelabs/wazero v1.0.0-pre.4 h1:RBJQT5OzmORkSp6MmZDWoFEr0zXjk4pmvMKAdeUnsaI=
+github.com/tetratelabs/wazero v1.0.0-pre.4/go.mod h1:u8wrFmpdrykiFK0DFPiFm5a4+0RzsdmXYVtijBKqUVo=

--- a/model/msgpack.go
+++ b/model/msgpack.go
@@ -9,11 +9,11 @@ import (
 
 var _ = convert.Package
 
-type ParserParseArgs struct {
+type parserParseArgs struct {
 	Source string `json:"source" yaml:"source" msgpack:"source"`
 }
 
-func (o *ParserParseArgs) Decode(decoder msgpack.Reader) error {
+func (o *parserParseArgs) Decode(decoder msgpack.Reader) error {
 	numFields, err := decoder.ReadMapSize()
 	if err != nil {
 		return err
@@ -39,7 +39,7 @@ func (o *ParserParseArgs) Decode(decoder msgpack.Reader) error {
 	return nil
 }
 
-func (o *ParserParseArgs) Encode(encoder msgpack.Writer) error {
+func (o *parserParseArgs) Encode(encoder msgpack.Writer) error {
 	if o == nil {
 		encoder.WriteNil()
 		return nil
@@ -51,12 +51,12 @@ func (o *ParserParseArgs) Encode(encoder msgpack.Writer) error {
 	return nil
 }
 
-type ResolverResolveArgs struct {
+type resolverResolveArgs struct {
 	Location string `json:"location" yaml:"location" msgpack:"location"`
 	From     string `json:"from" yaml:"from" msgpack:"from"`
 }
 
-func (o *ResolverResolveArgs) Decode(decoder msgpack.Reader) error {
+func (o *resolverResolveArgs) Decode(decoder msgpack.Reader) error {
 	numFields, err := decoder.ReadMapSize()
 	if err != nil {
 		return err
@@ -84,7 +84,7 @@ func (o *ResolverResolveArgs) Decode(decoder msgpack.Reader) error {
 	return nil
 }
 
-func (o *ResolverResolveArgs) Encode(encoder msgpack.Writer) error {
+func (o *resolverResolveArgs) Encode(encoder msgpack.Writer) error {
 	if o == nil {
 		encoder.WriteNil()
 		return nil

--- a/model/wapc.go
+++ b/model/wapc.go
@@ -27,7 +27,7 @@ func NewResolver(binding ...string) *ResolverImpl {
 }
 
 func (h *ResolverImpl) Resolve(ctx context.Context, location string, from string) (string, error) {
-	inputArgs := ResolverResolveArgs{
+	inputArgs := resolverResolveArgs{
 		Location: location,
 		From:     from,
 	}
@@ -56,7 +56,7 @@ func parserParseWrapper(svc Parser) wapc.Function {
 	return func(payload []byte) ([]byte, error) {
 		ctx := context.Background()
 		decoder := msgpack.NewDecoder(payload)
-		var inputArgs ParserParseArgs
+		var inputArgs parserParseArgs
 		inputArgs.Decode(&decoder)
 		response, err := svc.Parse(ctx, inputArgs.Source)
 		if err != nil {


### PR DESCRIPTION
This updates [wazero](https://wazero.io/) to [1.0.0-pre.4](https://github.com/tetratelabs/wazero/releases/tag/v1.0.0-pre.4).

Notably, v1.0.0-pre.4:
* improves module initialization speed
* supports listeners in the compiler engine
* supports WASI `fd_pread`, `fd_readdir` and `path_filestat_get`
* breaks GoModuleFunc API