### PR TITLE
deps: updates wazero to 1.0.0-rc.1

### DIFF
--- a/cmd/host/go.mod
+++ b/cmd/host/go.mod
@@ -4,5 +4,5 @@ go 1.19
 
 require (
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/tetratelabs/wazero v1.0.0-pre.6
+	github.com/tetratelabs/wazero v1.0.0-rc.1
 )

--- a/cmd/host/go.sum
+++ b/cmd/host/go.sum
@@ -1,4 +1,4 @@
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
-github.com/tetratelabs/wazero v1.0.0-pre.6 h1:3DRqjuHazHyZmgWCgqu7nKgYIYNEi2+2RQpCwTqbVHs=
-github.com/tetratelabs/wazero v1.0.0-pre.6/go.mod h1:u8wrFmpdrykiFK0DFPiFm5a4+0RzsdmXYVtijBKqUVo=
+github.com/tetratelabs/wazero v1.0.0-rc.1 h1:ytecMV5Ue0BwezjKh/cM5yv1Mo49ep2R2snSsQUyToc=
+github.com/tetratelabs/wazero v1.0.0-rc.1/go.mod h1:wYx2gNRg8/WihJfSDxA1TIL8H+GkfLYm+bIfbblu9VQ=

--- a/cmd/host/main.go
+++ b/cmd/host/main.go
@@ -51,7 +51,7 @@ func main() {
 		WithFunc(definitions.resolve).
 		WithParameterNames("location_ptr", "location_len", "from_ptr", "from_len").
 		Export("resolve").
-		Instantiate(ctx, r)
+		Instantiate(ctx)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
This updates [wazero](https://wazero.io/) to [1.0.0-rc.1][0].
This version does not change any public API, but it delivers
several bug fixes and improvements; including
* Full support to the WASI test suite and other third-party integration tests
* Fix for an issue with the context cancellation API
* A number of optimizations to reduce compilation overhead

This PR also includes changes required by [wazero](https://wazero.io/)
[1.0.0-pre.8][2] and [wazero](https://wazero.io/) [1.0.0-pre.9][1]. Notably:

* It requires at least Go 1.8
* This release also integrates Go context to limit execution time.
  More details on the [Release Notes][1]
* We are now passing third-party integration test suites: wasi-testsuite,
  TinyGo's, Zig's.
* Changes the `Instantiate` signature, which no longer requires
  an explicit `Runtime` instance.

[0]: https://github.com/tetratelabs/wazero/releases/tag/1.0.0-rc.1
[1]: https://github.com/tetratelabs/wazero/releases/tag/v1.0.0-pre.9
[2]: https://github.com/tetratelabs/wazero/releases/tag/v1.0.0-pre.8

Signed-off-by: Edoardo Vacchi <evacchi@users.noreply.github.com>
